### PR TITLE
fix selection of categories when editing the questions

### DIFF
--- a/jpfaq/Configuration/TCA/Question.php
+++ b/jpfaq/Configuration/TCA/Question.php
@@ -86,6 +86,7 @@ $TCA['tx_jpfaq_domain_model_question'] = array(
 			'label'		=> 'LLL:EXT:jpfaq/Resources/Private/Language/locallang_db.xml:tx_jpfaq_domain_model_question.category',
 			'config'	=> array(
 				'type' => 'select',
+				'renderType' => 'selectSingle',
 				'foreign_table' => 'tx_jpfaq_domain_model_category',
 				'MM' => 'tx_jpfaq_question_category_mm',
                             'foreign_sortby' => 'sorting',


### PR DESCRIPTION
avoid error Unknown type: select, render type: select
see also https://wiki.typo3.org/TYPO3.CMS/Releases/7.6/Deprecation#Deprecation:_.2369822_-_Deprecate_TCA_settings_of_select_fields